### PR TITLE
feat: simplify release workflow versioning by removing build numbers

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -4,44 +4,28 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number (e.g. 0.1.0)'
+        description: 'Version number (e.g. 0.0.1)'
         required: true
 
 jobs:
-  get_build_number:
-    runs-on: ubuntu-22.04
-    outputs:
-      build_number: ${{ steps.set_number.outputs.build_number }}
-    steps:
-      - name: Generate build number
-        id: set_number
-        run: |
-          echo "build_number=$(( $GITHUB_RUN_NUMBER ))" >> $GITHUB_OUTPUT
-
   build-x86_64:
-    needs: get_build_number
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-
       - name: Change Cargo.toml version
         run: |
-          VERSION="${{ github.event.inputs.version }}-build${{ needs.get_build_number.outputs.build_number }}"
+          VERSION="${{ github.event.inputs.version }}"
           sed -i "s/^version[ ]*=[ ]*\"[^\"]*\"/version = \"${VERSION}\"/" Cargo.toml
           echo "Updated version in Cargo.toml:"
           grep "^version" Cargo.toml
-
       - name: Build
         run: cargo build --release --target x86_64-unknown-linux-gnu
-
       - name: Create Release Tag
         run: |
-          TAG="v${{ github.event.inputs.version }}-build${{ needs.get_build_number.outputs.build_number }}"
+          TAG="v${{ github.event.inputs.version }}"
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
-
       - name: Zip artifact
         run: zip -j komandan_${{ env.RELEASE_TAG }}-linux-x86_64.zip target/x86_64-unknown-linux-gnu/release/komandan
-
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -50,29 +34,23 @@ jobs:
             komandan_${{ env.RELEASE_TAG }}-linux-x86_64.zip
 
   build-aarch64:
-    needs: get_build_number
     runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
-
       - name: Change Cargo.toml version
         run: |
-          VERSION="${{ github.event.inputs.version }}-build${{ needs.get_build_number.outputs.build_number }}"
+          VERSION="${{ github.event.inputs.version }}"
           sed -i "s/^version[ ]*=[ ]*\"[^\"]*\"/version = \"${VERSION}\"/" Cargo.toml
           echo "Updated version in Cargo.toml:"
           grep "^version" Cargo.toml
-
       - name: Build
         run: cargo build --release --target aarch64-unknown-linux-gnu
-
       - name: Create Release Tag
         run: |
-          TAG="v${{ github.event.inputs.version }}-build${{ needs.get_build_number.outputs.build_number }}"
+          TAG="v${{ github.event.inputs.version }}"
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
-
       - name: Zip artifact
         run: zip -j komandan_${{ env.RELEASE_TAG }}-linux-aarch64.zip target/aarch64-unknown-linux-gnu/release/komandan
-
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -82,7 +60,7 @@ jobs:
 
   release:
     runs-on: ubuntu-22.04
-    needs: [get_build_number, build-x86_64, build-aarch64]
+    needs: [build-x86_64, build-aarch64]
     permissions:
       contents: write
     steps:
@@ -90,17 +68,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-x86_64-artifact
-
       - name: Download artifact aarch64
         uses: actions/download-artifact@v4
         with:
           name: build-aarch64-artifact
-
       - name: Create Release Tag
         run: |
-          TAG="v${{ github.event.inputs.version }}-build${{ needs.get_build_number.outputs.build_number }}"
+          TAG="v${{ github.event.inputs.version }}"
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
-
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
@@ -113,33 +88,27 @@ jobs:
 
   docker-build-and-push:
     runs-on: ubuntu-22.04
-    needs: [get_build_number, release]
+    needs: [release]
     steps:
       - uses: actions/checkout@v4
-
       - name: Get version
         run: |
-          VERSION="${{ github.event.inputs.version }}-build${{ needs.get_build_number.outputs.build_number }}"
+          VERSION="${{ github.event.inputs.version }}"
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
-
       - name: Change Cargo.toml version
         run: |
           sed -i "s/^version[ ]*=[ ]*\"[^\"]*\"/version = \"${{ env.VERSION }}\"/" Cargo.toml
           echo "Updated version in Cargo.toml:"
           grep "^version" Cargo.toml
-
       - name: Build Docker image
         run: docker build -t hahnavi/komandan:${{ env.VERSION }} .
-
       - name: Retag image
         run: docker tag hahnavi/komandan:${{ env.VERSION }} hahnavi/komandan:latest
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-
       - name: Push Docker images
         run: |
           docker push hahnavi/komandan:${{ env.VERSION }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified release version tagging scheme to use v{version} format without build numbers in release identifiers.
  * Streamlined CI/CD workflow by optimizing job dependencies and removing redundant build numbering computation from the release pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->